### PR TITLE
(#2) update handling of custom tags to fulfill api requirements

### DIFF
--- a/Cataloguify/Cataloguify.Client/Pages/Dialogs/SearchImagesDialog.razor
+++ b/Cataloguify/Cataloguify.Client/Pages/Dialogs/SearchImagesDialog.razor
@@ -98,7 +98,16 @@
 
     private void AddNewTag()
     {
-        newTagValue = char.ToUpper(newTagValue[0]) + newTagValue[1..].ToLower();
+        var tagElements = newTagValue.Trim().Split(' ');
+        for (var i = 0; i < tagElements.Length; ++i)
+        {
+            if (tagElements[i].Length > 0)
+            {
+                tagElements[i] = char.ToUpper(tagElements[i][0]) + tagElements[i][1..].ToLower();
+            }
+        }
+
+        newTagValue = string.Join(' ', tagElements);
 
         var list = TempSearchImagesModel.Tags.ToHashSet();
         list.Add(newTagValue);


### PR DESCRIPTION
Simple fix at dialog for filtering images. There was need to provide suitable handling of tags composed from more than one word to have each word started from big letter.